### PR TITLE
Diego/responsivo

### DIFF
--- a/usuario.css
+++ b/usuario.css
@@ -97,6 +97,7 @@ button:hover {
         width: 50vw;
         height: auto;
         max-height: 300px;
+        margin-bottom: 20px;
     }
 
     .linea {
@@ -127,12 +128,12 @@ button:hover {
     .imagen-oso {
         width: 70vw;
         max-width: 200px;
+        margin-bottom: 20px;
     }
 
     .principal h1 {
         font-size: 20px;
         margin-bottom: 20px;
-        margin-top: 20px;
     }
 
     .principal h2, .principal h4 {

--- a/usuario.css
+++ b/usuario.css
@@ -106,6 +106,7 @@ button:hover {
     .principal h1 {
         font-size: 24px;
         margin-bottom: 30px;
+        margin-top: 20px;
     }
 
     .principal h2, .principal h4 {
@@ -131,6 +132,7 @@ button:hover {
     .principal h1 {
         font-size: 20px;
         margin-bottom: 20px;
+        margin-top: 20px;
     }
 
     .principal h2, .principal h4 {


### PR DESCRIPTION
Se realiza un agregado de `margin` a la imagen de la card de la segunda página ya que este se pegaba mucho al `h1` de "Datos Personales":

Tablets:


![image](https://github.com/user-attachments/assets/69aaec40-603a-4a8f-b83e-b14be1cabc76)


Móviles:


![image](https://github.com/user-attachments/assets/4c673fbb-3c7b-49a3-bb59-65fd7602a4f8)
